### PR TITLE
Fix method pushy.translate()

### DIFF
--- a/pushy.php
+++ b/pushy.php
@@ -473,6 +473,12 @@ class PushyPlugin extends Plugin
         $user = $this->grav['user'];
         $language = $user['language'];
 
-		return $this->grav['language']->translate(["$prefix.$key", $arg], [$language]);
+        $translation = $this->grav['language']->translate(["$prefix.$key", $arg], [$language]);
+
+        if ($translation == "$prefix.$key") {
+            $translation = $this->grav['language']->translate(["$prefix.$key", $arg], ['en']);
+        }
+
+        return $translation;
     }
 }


### PR DESCRIPTION
When language of Pushy user is not available in translation.yaml, Pushy admin will fail due to an TS/JS null exception.

See issue [Changes are not listed for users whose language is not translated by the plugin #35](https://github.com/hughbris/grav-plugin-pushy/issues/35)

Added fallback to English to prevent exception.